### PR TITLE
Add utf8 support and make sure to reset the view on reload

### DIFF
--- a/capture/field.c
+++ b/capture/field.c
@@ -113,6 +113,7 @@ void moloch_field_define_json(unsigned char *expression, int expression_len, uns
 int moloch_field_define_text_full(char *field, char *text, int *shortcut)
 {
     int count = 0;
+    int utf8 = 0;
     int nolinked = 0;
     char *kind = 0;
     char *help = 0;
@@ -138,6 +139,8 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
             kind = colon;
         else if (strcmp(elements[e], "group") == 0)
             group = colon;
+        else if (strcmp(elements[e], "utf8") == 0)
+            utf8 = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "count") == 0)
             count = strcmp(colon, "true") == 0;
         else if (strcmp(elements[e], "nolinked") == 0)
@@ -215,6 +218,9 @@ int moloch_field_define_text_full(char *field, char *text, int *shortcut)
             category = "ip";
     } else
         type = MOLOCH_FIELD_TYPE_STR_HASH;
+
+    if (utf8)
+        flags |= MOLOCH_FIELD_FLAG_FORCE_UTF8;
 
     if (count)
         flags |= MOLOCH_FIELD_FLAG_CNT;

--- a/wiseService/wiseSource.js
+++ b/wiseService/wiseSource.js
@@ -164,6 +164,7 @@ WISESource.prototype.parseFieldDef = function(line) {
 //////////////////////////////////////////////////////////////////////////////////
 WISESource.prototype.parseTagger = function(body, setCb, endCb) {
   var lines = body.toString().split(/\r?\n/);
+  this.view = "";
   for (var l = 0, llen = lines.length; l < llen; l++) {
     if (lines[l][0] === "#") {
       this.parseFieldDef(lines[l]);


### PR DESCRIPTION
This is the merge of two small PRs that I have staged against the origin master. They fix the lack of support of utf8 dynamically added fields. Also, whenever there is a reload, the view gets appended to rather than replacing it.
